### PR TITLE
Sentiment chart doesnt display the year

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     volumes:
       - './front-end:/usr/src/app'
       - '/usr/src/app/node_modules'
+    stdin_open: true
     ports:
       - 3000:3000
     env_file: './front-end/.env'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     volumes:
       - './front-end:/usr/src/app'
       - '/usr/src/app/node_modules'
-    stdin_open: true
     ports:
       - 3000:3000
     env_file: './front-end/.env'

--- a/front-end/src/routes/Timeline/Sentiment.view.js
+++ b/front-end/src/routes/Timeline/Sentiment.view.js
@@ -226,7 +226,12 @@ function Timeline() {
                   }}
                 >
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="year" tickMargin={15} />
+                  <XAxis
+                    type="number"
+                    domain={[yearFrom, yearTo]}
+                    dataKey="year"
+                    tickCount={Math.abs(yearTo - yearFrom)}
+                  />
                   <YAxis />
                   <Legend />
                   <Tooltip />
@@ -237,6 +242,7 @@ function Timeline() {
                     // stroke={stringToColour(sentiments.data.word)}
                     // fill={stringToColour(sentiments.data.word)}
                     strokeWidth={3}
+                    connectNulls
                     dot={{ strokeWidth: 5 }}
                     activeDot={{
                       //   stroke: stringToColour(sentiments.data.word),

--- a/front-end/src/routes/Timeline/Sentiment.view.js
+++ b/front-end/src/routes/Timeline/Sentiment.view.js
@@ -226,7 +226,7 @@ function Timeline() {
                   }}
                 >
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="yearRange" tickMargin={15} />
+                  <XAxis dataKey="year" tickMargin={15} />
                   <YAxis />
                   <Legend />
                   <Tooltip />


### PR DESCRIPTION
#### Solves:
- #328 

#### Additional Information:
- It also maintains the year range/ticks when there are null values.

[Code review checklist](https://github.com/op-analytics/NYT-Media-Analytics/wiki/Code-Review-Checklist)
